### PR TITLE
Added bunding DLL Injector to CI artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ after_build:
     $extractRoot = "$env:TEMP\Injector"
     $srcPath = Join-Path $extractRoot (Join-Path $injectorFolder "Injector.exe")
     if (-not (Test-Path $srcPath)) { $srcPath = Join-Path $extractRoot (Join-Path $env:PLATFORM "Injector.exe") }
-    $destDir = "bin\Release_LIB\$env:PLATFORM"
+    $destDir = "bin\$env:PLATFORM"
     Copy-Item $srcPath -Destination $destDir -Force
 artifacts:
 - path: 'bin\**\*.dll'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build pipeline now automatically downloads the Injector v1.4.0 release from GitHub and incorporates it into the build output.
  * The Injector executable is validated (when a checksum is provided), expanded, placed per platform, and packaged as a build artifact named "HydraHook".
  * These steps run after the build completes to streamline distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->