### PR TITLE
Fixed D3D10 and D3D11 present hooks both firing in a D3D10 game

### DIFF
--- a/src/HydraHook/Game/Game.cpp
+++ b/src/HydraHook/Game/Game.cpp
@@ -581,7 +581,6 @@ DWORD WINAPI HydraHookMainThread(LPVOID Params)
         {
             const std::unique_ptr<Direct3D10Hooking::Direct3D10> d3d10(new Direct3D10Hooking::Direct3D10);
             auto vtable = d3d10->vtable();
-            dxgiPresentAddress = vtable[DXGIHooking::Present];
 
             logger->info("Hooking IDXGISwapChain::Present");
 
@@ -648,6 +647,7 @@ DWORD WINAPI HydraHookMainThread(LPVOID Params)
 
                 return ret;
             });
+            dxgiPresentAddress = vtable[DXGIHooking::Present];
 
             logger->info("Hooking IDXGISwapChain::ResizeTarget");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate graphics-present handling when the older graphics path already manages presentation, reducing redundant rendering work.
  * Improved stability and logging during graphics initialization, lowering the risk of rendering glitches or conflicts across Direct3D versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->