### PR TITLE
Fixed D3D11 hooks being invoked when in D3D12 game

### DIFF
--- a/src/HydraHook/Game/Game.cpp
+++ b/src/HydraHook/Game/Game.cpp
@@ -799,6 +799,10 @@ DWORD WINAPI HydraHookMainThread(LPVOID Params)
                 ID3D11Device* pD11Device = nullptr;
                 if (FAILED(chain->GetDevice(IID_PPV_ARGS(&pD11Device))))
                 {
+                    if (pD11Device)
+                    {
+                        pD11Device->Release();
+                    }
                     return swapChainPresent11Hook.call_orig(chain, SyncInterval, Flags);
                 }
                 if (pD11Device)
@@ -854,6 +858,10 @@ DWORD WINAPI HydraHookMainThread(LPVOID Params)
                 ID3D11Device* pD11Device = nullptr;
                 if (FAILED(chain->GetDevice(IID_PPV_ARGS(&pD11Device))))
                 {
+                    if (pD11Device)
+                    {
+                        pD11Device->Release();
+                    }
                     return swapChainResizeTarget11Hook.call_orig(chain, pNewTargetParameters);
                 }
                 if (pD11Device)
@@ -907,6 +915,10 @@ DWORD WINAPI HydraHookMainThread(LPVOID Params)
                 ID3D11Device* pD11Device = nullptr;
                 if (FAILED(chain->GetDevice(IID_PPV_ARGS(&pD11Device))))
                 {
+                    if (pD11Device)
+                    {
+                        pD11Device->Release();
+                    }
                     return swapChainResizeBuffers11Hook.call_orig(chain,
                         BufferCount, Width, Height, NewFormat, SwapChainFlags);
                 }
@@ -1072,6 +1084,10 @@ DWORD WINAPI HydraHookMainThread(LPVOID Params)
                 ID3D12Device* pD12Device = nullptr;
                 if (FAILED(chain->GetDevice(IID_PPV_ARGS(&pD12Device))))
                 {
+                    if (pD12Device)
+                    {
+                        pD12Device->Release();
+                    }
                     return swapChainPresent12Hook.call_orig(chain, SyncInterval, Flags);
                 }
                 if (pD12Device)
@@ -1113,6 +1129,10 @@ DWORD WINAPI HydraHookMainThread(LPVOID Params)
                 ID3D12Device* pD12Device = nullptr;
                 if (FAILED(chain->GetDevice(IID_PPV_ARGS(&pD12Device))))
                 {
+                    if (pD12Device)
+                    {
+                        pD12Device->Release();
+                    }
                     return swapChainResizeTarget12Hook.call_orig(chain, pNewTargetParameters);
                 }
                 if (pD12Device)
@@ -1154,6 +1174,10 @@ DWORD WINAPI HydraHookMainThread(LPVOID Params)
                 ID3D12Device* pD12Device = nullptr;
                 if (FAILED(chain->GetDevice(IID_PPV_ARGS(&pD12Device))))
                 {
+                    if (pD12Device)
+                    {
+                        pD12Device->Release();
+                    }
                     return swapChainResizeBuffers12Hook.call_orig(chain,
                         BufferCount, Width, Height, NewFormat, SwapChainFlags);
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened defensive checks when interacting with graphics devices prior to rendering callbacks. Temporary device references are now acquired and released around present/resize operations, with safe fallback to original behavior on failure. Improves robustness of initialization and error handling across supported graphics APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->